### PR TITLE
corrected typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the blog series about this application:
 
 ### Deploying
 
-***Note: This stack inclused an Amazon CloudFront distrobution which can take around 30 minutes to create. Don't be alarmed if the deploy seems to hang for a long time.***
+***Note: This stack includes an Amazon CloudFront distribution which can take around 30 minutes to create. Don't be alarmed if the deploy seems to hang for a long time.***
 In the terminal, use the SAM CLI guided deployment the first time you deploy
 ```bash
 sam deploy -g

--- a/template.yaml
+++ b/template.yaml
@@ -185,9 +185,9 @@ Resources:
   AmplifyApp:
     Type: AWS::Amplify::App
     Properties:
-      Name: Url-Shortner-Client
+      Name: Url-Shortener-Client
       Description: Basic client for URL Shortner
-      Repository: https://github.com/aws-samples/amazon-api-gateway-url-shortener
+      Repository: !Ref GithubRepository
       AccessToken: !Ref PersonalAcessToken
       BuildSpec: |-
         version: 0.1


### PR DESCRIPTION
In template.yaml: Replaced hardcoded rhttps://github.com/aws-samples/amazon-api-gateway-url-shortener with !Ref GithubRepository and corrected minor typos

Corrected minor typos in README.md