### PR TITLE
Update template.yaml to resolve npm ERR

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -203,6 +203,7 @@ Resources:
             preBuild:
               commands:
                 - cd client
+                - npm install
                 - npm ci
             build:
               commands:


### PR DESCRIPTION
Resolve error: 
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
