### PR TITLE
fix(template.yaml): enable ACLs on cloudfront logging bucket and add bucket policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -187,6 +187,31 @@ Resources:
   ##   CloudFront access logs storage
   CloudFrontAccessLogsBucket:
     Type: AWS::S3::Bucket
+    Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
+      AccessControl: LogDeliveryWrite
+
+  CloudFrontAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CloudFrontAccessLogsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "${CloudFrontAccessLogsBucket.Arn}/*"
+          - Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action:
+              - s3:GetBucketAcl
+              - s3:PutBucketAcl
+            Resource: !GetAtt CloudFrontAccessLogsBucket.Arn
 
   ##   Amplify Application for hosting
   AmplifyApp:


### PR DESCRIPTION
*Description of changes:*
This Pull Request updates the configuration for the S3 bucket used to store CloudFront access logs. The changes ensure compatibility with AWS’s 2023 updates, where ACLs are disabled by default on new S3 buckets. 

Without these updates, the stack no longer deploys, as it shows the following error:
`Invalid request provided: AWS::CloudFront::Distribution:The S3 bucket that you specified for CloudFront logs does not enable ACL access:`

*Changes Introduced:*
- Enable ACLs:
    - Added ObjectOwnership: BucketOwnerPreferred to ensure all objects in the bucket are owned by the bucket owner, regardless of the uploader. This enables the ACLs on the bucket.
- Access Control:
    - Added AccessControl: LogDeliveryWrite to allow CloudFront to write access logs to the bucket.
- Bucket Policy:
    - Granted s3:PutObject permissions to the cloudfront.amazonaws.com service principal for log delivery.
    - Granted s3:GetBucketAcl and s3:PutBucketAcl permissions to cloudfront.amazonaws.com to manage ACLs as required.

*Reference:*
- AWS Documentation on the required configuration for CloudFront access logs with the new defaults:
[Access Logs - Bucket and File Ownership](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html#AccessLogsBucketAndFileOwnership)
- Blog Announcement about the S3 ACLs being disabled by default: [Heads-Up: Amazon S3 Security Changes Are Coming in April of 2023](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
